### PR TITLE
fix: Euler回転合成順をYXZに修正

### DIFF
--- a/pkg/domain/mmath/quaternion.go
+++ b/pkg/domain/mmath/quaternion.go
@@ -117,10 +117,11 @@ func NewQuaternionFromRadians(xPitch, yHead, zRoll float64) Quaternion {
 	cy, sy := math.Cos(yHead*0.5), math.Sin(yHead*0.5)
 	cz, sz := math.Cos(zRoll*0.5), math.Sin(zRoll*0.5)
 
-	w := cx*cy*cz - sx*sy*sz
-	x := sx*cy*cz + cx*sy*sz
-	y := cx*sy*cz - sx*cy*sz
-	z := cx*cy*sz + sx*sy*cz
+	// MMDの回転合成順（YXZ）に合わせて、qy * qx * qz の順で合成する。
+	w := cy*cz*cx + sy*sz*sx
+	x := cy*cz*sx + sy*sz*cx
+	y := sy*cz*cx - cy*sz*sx
+	z := cy*sz*cx - sy*cz*sx
 
 	return NewQuaternionByValues(x, y, z, w).Normalized()
 }

--- a/pkg/domain/mmath/quaternion_test.go
+++ b/pkg/domain/mmath/quaternion_test.go
@@ -149,6 +149,14 @@ func TestQuaternionConversions(t *testing.T) {
 	if !qd.IsIdent() {
 		t.Errorf("FromDegrees")
 	}
+	qyxz := NewQuaternionFromDegrees(10, 20, 30)
+	expectedYxz := NewQuaternionByValues(0.12767944069578063, 0.14487812541736914, 0.2392983377447303, 0.9515485246437885)
+	if !qyxz.NearEquals(expectedYxz, 1e-8) {
+		t.Errorf("FromDegrees YXZ: expected=%v got=%v", expectedYxz, qyxz)
+	}
+	if !qyxz.ToDegrees().NearEquals(Vec3{r3Vec(10, 20, 30)}, 1e-8) {
+		t.Errorf("FromDegrees->ToDegrees YXZ: got=%v", qyxz.ToDegrees())
+	}
 	if q.ToRadians() != (Vec3{r3Vec(0, 0, 0)}) {
 		t.Errorf("ToRadians")
 	}

--- a/pkg/shared/contracts/rotation/rotation.go
+++ b/pkg/shared/contracts/rotation/rotation.go
@@ -15,6 +15,8 @@ type EulerOrder int
 const (
 	// EULER_ORDER_XYZ はXYZ順を表す。
 	EULER_ORDER_XYZ EulerOrder = iota
+	// EULER_ORDER_YXZ はYXZ順を表す。
+	EULER_ORDER_YXZ
 	// EULER_ORDER_ZXY はZXY順を表す。
 	EULER_ORDER_ZXY
 	// EULER_ORDER_YZX はYZX順を表す。
@@ -55,7 +57,7 @@ const VMD_CAMERA_ROTATION_UNIT = "degree"
 // DEFAULT_ROTATION_POLICY は既定の回転ポリシー。
 var DEFAULT_ROTATION_POLICY = RotationPolicy{
 	QuaternionOrder:    QUATERNION_ORDER_XYZW,
-	EulerOrder:         EULER_ORDER_XYZ,
+	EulerOrder:         EULER_ORDER_YXZ,
 	IkLimitEulerOrders: []IkLimitEulerOrder{IK_LIMIT_EULER_ORDER_ZXY, IK_LIMIT_EULER_ORDER_XYZ, IK_LIMIT_EULER_ORDER_YZX},
 	Interpolation:      ROTATION_INTERPOLATION_SLERP,
 }

--- a/pkg/shared/contracts/rotation/rotation_test.go
+++ b/pkg/shared/contracts/rotation/rotation_test.go
@@ -8,7 +8,7 @@ func TestRotationPolicyDefault(t *testing.T) {
 	if DEFAULT_ROTATION_POLICY.QuaternionOrder != QUATERNION_ORDER_XYZW {
 		t.Errorf("QuaternionOrder: got=%v", DEFAULT_ROTATION_POLICY.QuaternionOrder)
 	}
-	if DEFAULT_ROTATION_POLICY.EulerOrder != EULER_ORDER_XYZ {
+	if DEFAULT_ROTATION_POLICY.EulerOrder != EULER_ORDER_YXZ {
 		t.Errorf("EulerOrder: got=%v", DEFAULT_ROTATION_POLICY.EulerOrder)
 	}
 	orders := DEFAULT_ROTATION_POLICY.IkLimitEulerOrders


### PR DESCRIPTION
## 概要
- NewQuaternionFromRadians の Euler 合成順を YXZ に修正
- 回転ポリシーに EULER_ORDER_YXZ を追加
- 既定の EulerOrder を EULER_ORDER_YXZ に変更
- YXZ 前提のテストを追加・更新

## 変更ファイル
- pkg/domain/mmath/quaternion.go
- pkg/domain/mmath/quaternion_test.go
- pkg/shared/contracts/rotation/rotation.go
- pkg/shared/contracts/rotation/rotation_test.go

## 検証
- GOCACHE=/tmp/go-build go test ./...
- python3 ../mlib_skills/skills/00_project/060_mlib_i18n_key_checks/scripts/check_i18n_keys.py .
